### PR TITLE
Allow `sessionInfo` to be passed as parameter to start a session

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,8 +230,13 @@ class StreamingAvatar {
     this.voiceChat?.unmute();
   }
 
-  public async createStartAvatar(requestData: StartAvatarRequest): Promise<any> {
+
+  public async createStartAvatar(requestData: StartAvatarRequest): Promise<StartAvatarResponse> {
     const sessionInfo = await this.newSession(requestData);
+    return this.startAvatar(requestData, sessionInfo)
+  }
+
+  public async startAvatar(requestData: StartAvatarRequest, sessionInfo: StartAvatarResponse): Promise<StartAvatarResponse> {
     this.sessionId = sessionInfo.session_id;
     this.isLiveKitTransport =
       requestData.voiceChatTransport === VoiceChatTransport.LIVEKIT;


### PR DESCRIPTION
This might also be a security warning for existing users, i'm gonna leave an explaination of why:

We are building a service that allows to videocall with an avatar, and we were experimenting with heygen streaming avatar.

In our application, users have a "limit" on calls (paid by the minute, if they run out, the session needs to be stopped), this means that to securely implement it, the session is to be considered "started" from the moment that the session token is passed to the client.

To be able to interrupt the call on behalf of the user (say because they ran out of call minutes in our case), we need to be able to know the `session_id`.

But the only way to get this `session_id` is if the client itself gives it back to our backend service, but this is not safe, as a possible "attacker" could intercept this call (or just steal the session token itself before the session.new is called), and let the conversation continue infinitely, making us use the paid heygen service without our control (only way to stop this would be to poll the active sessions and guess which one was of the attacker, and stop the session)

To remedy this, our backend service should be the one to call the `streaming.new` endpoint (which can be called only once per session token), we'd also know the session_id, so we can stop the session once the user runs out of their call minutes, eliminating the security issue. 

This PR allows for that, being able to start a session, having it already created elsewhere. I kept the original method to not have a breaking change for existing users  